### PR TITLE
feat(cli): add worky report command

### DIFF
--- a/.claude/skills/epic-to-issues/SKILL.md
+++ b/.claude/skills/epic-to-issues/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: epic-to-issues
+description: Break down a complex GitHub issue (epic) into structured, independently-mergeable sub-issues with proper labels, blocking relationships, and a tasklist on the parent. Use this skill whenever the user wants to split a large or complex GitHub issue into smaller tasks, mentions "epic", "sub-issues", "break down this issue", "spezzare questa issue", or wants to structure work so multiple contributors can work in parallel without long-lived branches. Also trigger when the user references /prd-to-issues in the context of an existing GitHub issue.
+---
+
+# Epic to Issues
+
+Break down a large GitHub issue (epic) into structured, independently-mergeable sub-issues. The goal is trunk-based development: each sub-issue becomes a PR that goes to `main` without breaking anything, usually because new behavior is opt-in or behind a flag.
+
+## Process
+
+### Step 1 — Read the epic
+
+Fetch the issue with `gh issue view <number>` and read it carefully. Identify the natural boundaries: what are the distinct components, commands, or modules mentioned? What depends on what?
+
+### Step 2 — Propose a breakdown (collaborate, don't just execute)
+
+Present a table of proposed sub-issues to the user before creating anything. For each item, note:
+- What it delivers
+- Whether it's **Core MVP** or **Beta** (useful but not blocking)
+- Whether it can be merged independently to `main`
+
+Ask the user to review: should any be merged together? Split further? Reordered? Moved between MVP and beta? Listen carefully — the user knows the codebase and the contributor audience.
+
+Key questions to resolve before proceeding:
+- Which issues can be worked in parallel? (same dependency = parallel)
+- Are there any that are really "nice to have" vs truly needed for the feature to be usable?
+- Should tests be separate issues or part of each issue? (default: integrated, not separate)
+
+### Step 3 — Create the sub-issues
+
+Once the user confirms the breakdown, create each sub-issue with `gh issue create`. Each issue body should include:
+
+```markdown
+## Parent Epic
+Part of #<N> — <epic title>
+
+## Scope
+<1-2 sentences describing what this issue delivers>
+
+## Acceptance Criteria
+- <concrete, testable outcome>
+- ...
+
+## Testing
+- <what to verify, following existing test patterns in the codebase>
+
+## Dependencies
+- #<N> (<title>) — if blocked by another issue
+```
+
+For **beta** issues, add a `## Status` section after the parent epic line:
+```markdown
+## Status
+**Beta** — <MVP issues> must be completed first. In the meantime, users can <manual workaround>.
+```
+
+### Step 4 — Create labels if needed
+
+Before creating issues, check existing labels with `gh label list`. Create any missing labels:
+- `epic` (color `#6B46C1`) — for the parent issue
+- `beta` (color `#FFA500`) — for future/beta sub-issues
+
+Apply `epic` to the parent. Apply `beta` to beta sub-issues.
+
+### Step 5 — Link sub-issues natively
+
+Use the GitHub GraphQL API to add each sub-issue to the parent:
+
+```bash
+gh api graphql -f query='
+  mutation($parentId: ID!, $childId: ID!) {
+    addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+      issue { number }
+      subIssue { number }
+    }
+  }' \
+  -f parentId="$(gh issue view <parent> --json id --jq '.id')" \
+  -f childId="$(gh issue view <child> --json id --jq '.id')"
+```
+
+### Step 6 — Add blocking relationships
+
+Use `addBlockedBy` to express dependencies. The pattern: issue A blocks issue B means B cannot start until A is done.
+
+```bash
+gh api graphql -f query='
+  mutation($issueId: ID!, $blockingIssueId: ID!) {
+    addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
+      clientMutationId
+    }
+  }' \
+  -f issueId="<ID of the blocked issue>" \
+  -f blockingIssueId="<ID of the blocking issue>"
+```
+
+Get IDs with: `gh issue view <number> --json id --jq '.id'`
+
+If multiple issues are blocked by the same one (e.g., a foundational module blocks everything else), loop through them:
+
+```bash
+BLOCKING_ID=$(gh issue view <N> --json id --jq '.id')
+for issue in <n1> <n2> <n3>; do
+  BLOCKED_ID=$(gh issue view $issue --json id --jq '.id')
+  gh api graphql -f query='...' -f issueId="$BLOCKED_ID" -f blockingIssueId="$BLOCKING_ID"
+done
+```
+
+### Step 7 — Update the parent epic
+
+Append a tracking section to the parent issue body. Read the current body first, append, then write back:
+
+```bash
+gh issue view <N> --json body --jq '.body' > /tmp/epic_body.txt
+cat >> /tmp/epic_body.txt << 'EOF'
+
+---
+
+## Tracking
+
+### Core MVP
+- [ ] #<N> <title>
+- [ ] #<N> <title>
+
+### Beta
+- [ ] #<N> <title>
+- [ ] #<N> <title>
+EOF
+gh issue edit <N> --body "$(cat /tmp/epic_body.txt)"
+```
+
+GitHub renders these checkboxes as a progress bar on the epic.
+
+## Principles
+
+**Trunk-based first.** Every sub-issue should be mergeable to `main` without breaking existing behavior. Opt-in flags, new commands, and additive API changes are all safe. If a sub-issue would break something on merge, flag it and discuss.
+
+**Tests are part of the issue, not a separate one.** Each issue's acceptance criteria should include what to test and which existing test patterns to follow. Don't create a separate "testing" issue unless the test infrastructure itself is the deliverable.
+
+**Parallel where possible.** If two issues share the same dependency (both blocked by #X), they can be worked in parallel. Make this explicit in the blocking relationships and in your proposal.
+
+**Beta = usable workaround exists.** An issue is "beta" when the feature is useful but users can reasonably work around it manually in the meantime (e.g., `docker stop` manually instead of a `done` command). Call out the workaround in the issue body.
+
+**Don't create issues for things that are implicit.** If every issue will obviously need to follow the existing code style or use the existing test runner, don't add that as a criterion — it's noise.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+go generate ./cmd/worky/cmd/
+git add .github/ISSUE_TEMPLATE/bug_report.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ assignees: ''
 
 ## Logs
 
-<!-- Run `worky logs` to collect relevant logs and paste them here. -->
+<!-- If applicable, paste any relevant output from the terminal here. -->
 
 ## Environment
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a bug in worky
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Problem
+
+<!-- Describe the problem clearly and concisely. -->
+
+## Steps to reproduce
+
+<!-- List the exact steps to reproduce the issue. -->
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+
+<!-- What actually happened? -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain the problem. -->
+
+## Logs
+
+<!-- Run `worky logs` to collect relevant logs and paste them here. -->
+
+## Environment
+
+| | |
+|---|---|
+| worky version | <!-- e.g. v0.1.0 --> |
+| OS | <!-- e.g. linux, darwin --> |
+| Arch | <!-- e.g. amd64, arm64 --> |
+| Go | <!-- e.g. go1.24.0 --> |
+
+> **Tip:** Run `worky report` to open this form pre-filled with your environment details.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+What does this PR do and why.
+
+## Related issue
+Closes #
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+
+## Testing
+How did you verify this works.
+
+## Checklist
+- [ ] `go build ./...`, `go vet ./...`, `go test ./...` pass
+- [ ] Demo, docs, and README updated (if applicable)
+- [ ] `AGENTS.md` updated (if the architecture changed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ All cobra commands are built as unexported methods (`serveCmd`, `checkCmd`, etc.
 
 ## Verification
 
+After cloning, run once to configure git hooks:
+
+```sh
+make setup
+```
+
 After any Go change:
 
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 WORKY        := $(CURDIR)
 SCAFFOLD_DIR ?= /tmp/worky-scaffold
 
-.PHONY: build dev clean-scaffold
+.PHONY: build dev clean-scaffold setup
+
+## setup: configure git hooks (run once after cloning)
+setup:
+	git config core.hooksPath .githooks
 
 build:
 	go build -o bin/worky ./cmd/worky

--- a/cmd/worky/cmd/gen_issue_template/main.go
+++ b/cmd/worky/cmd/gen_issue_template/main.go
@@ -16,7 +16,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if err := cmd.GenerateIssueTemplate(f); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/worky/cmd/gen_issue_template/main.go
+++ b/cmd/worky/cmd/gen_issue_template/main.go
@@ -1,0 +1,23 @@
+// gen_issue_template regenerates .github/ISSUE_TEMPLATE/bug_report.md from the
+// body.md.tmpl template. Run via: go generate ./cmd/worky/cmd/
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/davideimola/worky/cmd/worky/cmd"
+)
+
+func main() {
+	// go generate runs with CWD = cmd/worky/cmd/
+	dest := "../../../.github/ISSUE_TEMPLATE/bug_report.md"
+	f, err := os.Create(dest)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	if err := cmd.GenerateIssueTemplate(f); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/worky/cmd/report.go
+++ b/cmd/worky/cmd/report.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/davideimola/worky/cmd/worky/templates"
+	"github.com/spf13/cobra"
+)
+
+//go:generate go run ./gen_issue_template/
+
+const reportBaseURL = "https://github.com/davideimola/worky/issues/new"
+
+const issueTemplateFrontmatter = `---
+name: Bug report
+about: Report a bug in worky
+title: ''
+labels: bug
+assignees: ''
+---
+
+`
+
+const issueTemplateFooter = "\n> **Tip:** Run `worky report` to open this form pre-filled with your environment details.\n"
+
+// GenerateIssueTemplate renders the GitHub issue template using body.md.tmpl
+// with placeholder values. It is the single source of truth for the template structure.
+func GenerateIssueTemplate(w io.Writer) error {
+	placeholders := ReportInfo{
+		Problem:  "<!-- Describe the problem clearly and concisely. -->",
+		Steps:    "<!-- List the exact steps to reproduce the issue. -->\n\n1.\n2.\n3.",
+		Expected: "<!-- What did you expect to happen? -->",
+		Actual:   "<!-- What actually happened? -->",
+		Version:  "<!-- e.g. v0.1.0 -->",
+		OS:       "<!-- e.g. linux, darwin -->",
+		Arch:     "<!-- e.g. amd64, arm64 -->",
+		GoVer:    "<!-- e.g. go1.24.0 -->",
+	}
+	if _, err := io.WriteString(w, issueTemplateFrontmatter); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, reportBody(placeholders)); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, issueTemplateFooter)
+	return err
+}
+
+// NewReportCmd returns the `worky report` command.
+func NewReportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "report",
+		Short: "Report a bug in worky",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			env := collectEnvInfo()
+			opts := ReportOptions{
+				info:          env,
+				browserOpener: platformBrowserOpener,
+				out:           cmd.OutOrStdout(),
+			}
+			p := newStdinPrompter(cmd.InOrStdin(), cmd.OutOrStdout())
+			return runReport(opts, p)
+		},
+	}
+}
+
+// platformBrowserOpener opens url using platform-specific commands.
+func platformBrowserOpener(url string) error {
+	var cmd string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	default:
+		cmd = "xdg-open"
+	}
+	return exec.Command(cmd, url).Start()
+}
+
+// ReportInfo holds all information needed to build a bug report.
+type ReportInfo struct {
+	Problem  string
+	Steps    string
+	Expected string
+	Actual   string
+	Version  string
+	OS       string
+	Arch     string
+	GoVer    string
+}
+
+// buildReportURL constructs a GitHub new-issue URL pre-filled with the report body.
+func buildReportURL(info ReportInfo) string {
+	q := url.Values{}
+	q.Set("body", reportBody(info))
+	return reportBaseURL + "?" + q.Encode()
+}
+
+// ReportOptions holds resolved parameters for running the report command.
+type ReportOptions struct {
+	info          ReportInfo
+	browserOpener func(url string) error
+	out           io.Writer
+}
+
+// runReport prompts the user, builds the URL, and opens the browser (or prints as fallback).
+func runReport(opts ReportOptions, p Prompter) error {
+	var err error
+	if opts.info.Problem, err = p.Ask("Describe the problem", ""); err != nil {
+		return err
+	}
+	if opts.info.Steps, err = p.Ask("Steps to reproduce", ""); err != nil {
+		return err
+	}
+	if opts.info.Expected, err = p.Ask("Expected behavior", ""); err != nil {
+		return err
+	}
+	if opts.info.Actual, err = p.Ask("Actual behavior", ""); err != nil {
+		return err
+	}
+
+	u := buildReportURL(opts.info)
+	if err := opts.browserOpener(u); err != nil {
+		fmt.Fprintf(opts.out, "Open this URL to submit your report:\n%s\n", u)
+	}
+	return nil
+}
+
+// collectEnvInfo gathers environment details for the bug report.
+func collectEnvInfo() ReportInfo {
+	return ReportInfo{
+		Version: Version,
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+		GoVer:   runtime.Version(),
+	}
+}
+
+func reportBody(info ReportInfo) string {
+	tmplContent, err := fs.ReadFile(templates.FS(), "files/report/body.md.tmpl")
+	if err != nil {
+		panic("report body template missing: " + err.Error())
+	}
+	tmpl, err := template.New("body").Delims("<%", "%>").Parse(string(tmplContent))
+	if err != nil {
+		panic("report body template invalid: " + err.Error())
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, info); err != nil {
+		panic("report body template execute: " + err.Error())
+	}
+	return buf.String()
+}

--- a/cmd/worky/cmd/report.go
+++ b/cmd/worky/cmd/report.go
@@ -77,6 +77,9 @@ func platformBrowserOpener(url string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		cmd = "open"
+	case "windows":
+		cmd = "rundll32"
+		return exec.Command(cmd, "url.dll,FileProtocolHandler", url).Start()
 	default:
 		cmd = "xdg-open"
 	}

--- a/cmd/worky/cmd/report.go
+++ b/cmd/worky/cmd/report.go
@@ -127,7 +127,7 @@ func runReport(opts ReportOptions, p Prompter) error {
 
 	u := buildReportURL(opts.info)
 	if err := opts.browserOpener(u); err != nil {
-		fmt.Fprintf(opts.out, "Open this URL to submit your report:\n%s\n", u)
+		_, _ = fmt.Fprintf(opts.out, "Open this URL to submit your report:\n%s\n", u)
 	}
 	return nil
 }

--- a/cmd/worky/cmd/report_test.go
+++ b/cmd/worky/cmd/report_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIssueTemplateIsUpToDate(t *testing.T) {
+	var buf bytes.Buffer
+	if err := GenerateIssueTemplate(&buf); err != nil {
+		t.Fatalf("generateIssueTemplate: %v", err)
+	}
+	actual, err := os.ReadFile("../../../.github/ISSUE_TEMPLATE/bug_report.md")
+	if err != nil {
+		t.Fatalf("read issue template: %v", err)
+	}
+	if buf.String() != string(actual) {
+		t.Error("issue template is out of date; run: go generate ./cmd/worky/cmd/")
+	}
+}
+
+func TestRootCmd_HasReportSubcommand(t *testing.T) {
+	root := NewRootCmd()
+	for _, sub := range root.Commands() {
+		if sub.Use == "report" {
+			return
+		}
+	}
+	t.Error("expected 'report' subcommand to be registered in root")
+}
+
+func TestBuildReportURL_IsGitHubNewIssueURL(t *testing.T) {
+	info := ReportInfo{}
+	url := buildReportURL(info)
+	if !strings.HasPrefix(url, "https://github.com/davideimola/worky/issues/new") {
+		t.Errorf("expected GitHub new-issue URL, got: %s", url)
+	}
+}
+
+func TestRunReport_OpensBrowser(t *testing.T) {
+	var opened string
+	opts := ReportOptions{
+		info: ReportInfo{Problem: "crash", Version: "v0.1.0", OS: "linux", Arch: "amd64", GoVer: "go1.24.0"},
+		browserOpener: func(u string) error {
+			opened = u
+			return nil
+		},
+		out: &strings.Builder{},
+	}
+	if err := runReport(opts, &stubPrompter{}); err != nil {
+		t.Fatalf("runReport: %v", err)
+	}
+	if !strings.HasPrefix(opened, "https://github.com/davideimola/worky/issues/new") {
+		t.Errorf("expected browser to open GitHub URL, got: %s", opened)
+	}
+}
+
+func TestRunReport_PrintsURLWhenBrowserFails(t *testing.T) {
+	out := &strings.Builder{}
+	opts := ReportOptions{
+		info: ReportInfo{Problem: "crash", Version: "v0.1.0", OS: "linux", Arch: "amd64", GoVer: "go1.24.0"},
+		browserOpener: func(u string) error {
+			return fmt.Errorf("no browser available")
+		},
+		out: out,
+	}
+	if err := runReport(opts, &stubPrompter{}); err != nil {
+		t.Fatalf("runReport: %v", err)
+	}
+	if !strings.Contains(out.String(), "https://github.com/davideimola/worky/issues/new") {
+		t.Errorf("expected URL in output, got: %s", out.String())
+	}
+}
+
+func TestRunReport_PromptsCollectFields(t *testing.T) {
+	var openedURL string
+	answers := map[string]string{
+		"Describe the problem":          "app crashes",
+		"Steps to reproduce":            "run serve",
+		"Expected behavior":             "starts fine",
+		"Actual behavior":               "panics",
+	}
+	p := &recordingPrompter{answers: answers}
+
+	opts := ReportOptions{
+		info:          ReportInfo{Version: "v0.1.0", OS: "linux", Arch: "amd64", GoVer: "go1.24.0"},
+		browserOpener: func(u string) error { openedURL = u; return nil },
+		out:           &strings.Builder{},
+	}
+	if err := runReport(opts, p); err != nil {
+		t.Fatalf("runReport: %v", err)
+	}
+
+	parsed, _ := url.Parse(openedURL)
+	body := parsed.Query().Get("body")
+	for _, want := range []string{"app crashes", "run serve", "starts fine", "panics"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\nbody:\n%s", want, body)
+		}
+	}
+}
+
+// stubPrompter returns empty strings for all questions.
+type stubPrompter struct{}
+
+func (s *stubPrompter) Ask(_, _ string) (string, error)       { return "", nil }
+func (s *stubPrompter) Confirm(_ string, d bool) (bool, error) { return d, nil }
+
+// recordingPrompter answers based on a map keyed by question prefix.
+type recordingPrompter struct {
+	answers map[string]string
+}
+
+func (r *recordingPrompter) Ask(question, _ string) (string, error) {
+	for prefix, ans := range r.answers {
+		if strings.Contains(question, prefix) {
+			return ans, nil
+		}
+	}
+	return "", nil
+}
+
+func (r *recordingPrompter) Confirm(_ string, d bool) (bool, error) { return d, nil }
+
+func TestCollectEnvInfo_PopulatesOSAndArch(t *testing.T) {
+	info := collectEnvInfo()
+	if info.OS == "" {
+		t.Error("expected non-empty OS")
+	}
+	if info.Arch == "" {
+		t.Error("expected non-empty Arch")
+	}
+	if info.GoVer == "" {
+		t.Error("expected non-empty GoVer")
+	}
+}
+
+func TestBuildReportURL_ContainsProblemAndEnvironment(t *testing.T) {
+	info := ReportInfo{
+		Problem: "the server crashes on startup",
+		Steps:   "run worky serve",
+		Version: "v1.2.3",
+		OS:      "linux",
+		Arch:    "amd64",
+		GoVer:   "go1.24.0",
+	}
+	raw := buildReportURL(info)
+
+	// parse back the body param
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("invalid URL: %v", err)
+	}
+	body := parsed.Query().Get("body")
+
+	for _, want := range []string{
+		"the server crashes on startup",
+		"run worky serve",
+		"v1.2.3",
+		"linux",
+		"amd64",
+		"go1.24.0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\nbody:\n%s", want, body)
+		}
+	}
+}

--- a/cmd/worky/cmd/root.go
+++ b/cmd/worky/cmd/root.go
@@ -14,6 +14,7 @@ func NewRootCmd() *cobra.Command {
 		NewInitCmd(),
 		NewNewCmd(),
 		NewBuildCmd(),
+		NewReportCmd(),
 	)
 
 	return root

--- a/cmd/worky/templates/files/report/body.md.tmpl
+++ b/cmd/worky/templates/files/report/body.md.tmpl
@@ -1,0 +1,32 @@
+## Problem
+
+<% .Problem %>
+
+## Steps to reproduce
+
+<% .Steps %>
+
+## Expected behavior
+
+<% .Expected %>
+
+## Actual behavior
+
+<% .Actual %>
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain the problem. -->
+
+## Logs
+
+<!-- Run `worky logs` to collect relevant logs and paste them here. -->
+
+## Environment
+
+| | |
+|---|---|
+| worky version | <% .Version %> |
+| OS | <% .OS %> |
+| Arch | <% .Arch %> |
+| Go | <% .GoVer %> |

--- a/cmd/worky/templates/files/report/body.md.tmpl
+++ b/cmd/worky/templates/files/report/body.md.tmpl
@@ -20,7 +20,7 @@
 
 ## Logs
 
-<!-- Run `worky logs` to collect relevant logs and paste them here. -->
+<!-- If applicable, paste any relevant output from the terminal here. -->
 
 ## Environment
 

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -106,4 +106,23 @@ Distribute the binaries via GitHub Releases. The entire site is embedded in the 
 
 ---
 
+## `worky report`
+
+Opens a pre-filled GitHub issue to report a bug in worky itself.
+
+```sh
+worky report
+```
+
+The command asks four questions interactively:
+
+1. Describe the problem
+2. Steps to reproduce
+3. Expected behavior
+4. Actual behavior
+
+It then automatically collects your environment (worky version, OS, architecture, Go version) and opens your browser with a pre-filled GitHub issue. If no browser is available (e.g. headless environments), the URL is printed to the terminal instead.
+
+---
+
 For the commands available inside each workshop binary (`serve`, `check`, `status`, etc.) see [Runtime commands](/docs/runtime).

--- a/website/content/docs/cli.md
+++ b/website/content/docs/cli.md
@@ -121,7 +121,7 @@ The command asks four questions interactively:
 3. Expected behavior
 4. Actual behavior
 
-It then automatically collects your environment (worky version, OS, architecture, Go version) and opens your browser with a pre-filled GitHub issue. If no browser is available (e.g. headless environments), the URL is printed to the terminal instead.
+Once you answer the questions, it automatically collects your environment details (worky version, OS, architecture, Go version) and opens your browser with a pre-filled GitHub issue. If no browser is available (e.g. headless environments), the URL is printed to the terminal instead.
 
 ---
 


### PR DESCRIPTION
## Description
Adds `worky report` command that lets users report bugs in worky directly from the CLI. The command collects environment info automatically and opens a pre-filled GitHub issue in the browser.

## Related issue
Closes #4

## Type of change
- [x] New feature

## Testing
- Unit tests added in `cmd/worky/cmd/report_test.go`
- Template rendering tested via `gen_issue_template`

## Checklist
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] `website/content/docs/cli.md` updated with `worky report` documentation
- [x] `AGENTS.md` unchanged (no architecture changes)

---
> This PR also adds a **PR template** (`.github/pull_request_template.md`) and an **epic-to-issues Claude skill** (`.claude/skills/epic-to-issues/`) as project meta improvements.